### PR TITLE
Fix wrong function called for pattern property in WalkCreate.

### DIFF
--- a/addon/parser.cpp
+++ b/addon/parser.cpp
@@ -783,7 +783,7 @@ void NodeBin::WalkOnCreate() const {
 void NodeBin::WalkCreate() const {
   AddMember("type", "create");
   AddMember("unique", (bool)cypher_ast_create_is_unique(node));
-  Node("pattern", cypher_ast_merge_get_pattern_path);
+  Node("pattern", cypher_ast_create_get_pattern);
 }
 
 void NodeBin::WalkSet() const {

--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
     "build": "npm run build-ts && npm run tslint"
   },
   "dependencies": {
-    "cypher-parser": "^0.1.0"
+    "cypher-parser": "^0.1.2"
   },
   "devDependencies": {
     "@types/node": "^10.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypher-parser",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A Node addon on top of libcypher-parser, used to parse and lint cypher queries.",
   "os": [
     "darwin",


### PR DESCRIPTION
Fixes https://github.com/Loupi/node-cypher-parser/issues/5