### PR TITLE
make context aware

### DIFF
--- a/addon/binding.cpp
+++ b/addon/binding.cpp
@@ -143,4 +143,6 @@ NAN_MODULE_INIT(InitAll) {
   Export(target, "parse", Parse);
 }
 
-NODE_MODULE(Cypher, InitAll)
+NODE_MODULE_INIT() {
+  InitAll(exports)
+}


### PR DESCRIPTION
Fixes #36 

This seems to work, at least in so far as the tests all pass, and the same change in other libs has resulted in those libs now loading correctly in worker_thread, however I cannot get `npm install` to work correctly when referring to this github repo with e.g.

```
"cypher-parser": "git+https://github.com/steveliles/node-cypher-parser.git"
```

... it just doesn't produce any js files in /dist, so I assume there's some build step that i'm missing? (it also doesn't work when referring directly to master on `https://github.com/loupi/node-cypher-parser.git` so it doesn't seem to be related to my change.