### PR TITLE
add arm support with node 16, 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "linux"
   ],
   "cpu": [
-    "x64"
+    "x64",
+    "arm64"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
I have modified the package.json to support ARM on Linux and macOS. And attached are the binaries for the same.
If you can add them to the S3 bucket, the package can be used on Apple Silicon and ARM Linux.

Fixes https://github.com/Loupi/node-cypher-parser/issues/33

[cypher-v0.1.13-node-v108-darwin-arm64.tar.gz](https://github.com/Loupi/node-cypher-parser/files/11766937/cypher-v0.1.13-node-v108-darwin-arm64.tar.gz)
[cypher-v0.1.13-node-v108-darwin-x64.tar.gz](https://github.com/Loupi/node-cypher-parser/files/11766938/cypher-v0.1.13-node-v108-darwin-x64.tar.gz)
[cypher-v0.1.13-node-v108-linux-arm64.tar.gz](https://github.com/Loupi/node-cypher-parser/files/11766939/cypher-v0.1.13-node-v108-linux-arm64.tar.gz)
[cypher-v0.1.13-node-v108-linux-x64.tar.gz](https://github.com/Loupi/node-cypher-parser/files/11766940/cypher-v0.1.13-node-v108-linux-x64.tar.gz)
[cypher-v0.1.13-node-v83-darwin-x64.tar.gz](https://github.com/Loupi/node-cypher-parser/files/11766929/cypher-v0.1.13-node-v83-darwin-x64.tar.gz)
[cypher-v0.1.13-node-v83-linux-arm64.tar.gz](https://github.com/Loupi/node-cypher-parser/files/11766930/cypher-v0.1.13-node-v83-linux-arm64.tar.gz)
[cypher-v0.1.13-node-v83-linux-x64.tar.gz](https://github.com/Loupi/node-cypher-parser/files/11766931/cypher-v0.1.13-node-v83-linux-x64.tar.gz)
[cypher-v0.1.13-node-v93-darwin-arm64.tar.gz](https://github.com/Loupi/node-cypher-parser/files/11766932/cypher-v0.1.13-node-v93-darwin-arm64.tar.gz)
[cypher-v0.1.13-node-v93-darwin-x64.tar.gz](https://github.com/Loupi/node-cypher-parser/files/11766934/cypher-v0.1.13-node-v93-darwin-x64.tar.gz)
[cypher-v0.1.13-node-v93-linux-arm64.tar.gz](https://github.com/Loupi/node-cypher-parser/files/11766935/cypher-v0.1.13-node-v93-linux-arm64.tar.gz)
[cypher-v0.1.13-node-v93-linux-x64.tar.gz](https://github.com/Loupi/node-cypher-parser/files/11766936/cypher-v0.1.13-node-v93-linux-x64.tar.gz)
